### PR TITLE
Upgrade exemel to support python3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
+    - "3.8"
 install:
     - pip install tox-travis
 script: tox

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The return value would be an XML string equivalent to:
 The ``build`` function accepts a single positional argument: the dictionary-like object to convert into the root element. It also accepts two keyword arguments. The first, ``root``, can be used to supply a tag for the root element. If the argument is not provided, the root element will be named 'root'. The second, ``encoding``, determines the encoding of the resulting string. It defaults to a byte string if no argument is provided.
 
 ### Dictionaries
-Any dictionary-like object (an instance of ``collections.Mapping``) will be converted into an XML element. Each key in the dictionary is used to add sub-elements, attributes, or other properties to that element.
+Any dictionary-like object (an instance of ``collections.abc.Mapping``) will be converted into an XML element. Each key in the dictionary is used to add sub-elements, attributes, or other properties to that element.
 
 Any key that is not a decorator (see *Decorators*) will add one or more sub-elements.
 
@@ -75,7 +75,7 @@ xml = exemel.build(ordered_dict)
 ```
 
 ### Iterables
-Any non-string iterable (an instance of ``collections.Iterable`` but not ``basestring``) will be converted into ordered sibling XML elements with the same tag. List items may be basic literals or dictionaries (they can be mixed).
+Any non-string iterable (an instance of ``collections.abc.Iterable`` but not ``basestring``) will be converted into ordered sibling XML elements with the same tag. List items may be basic literals or dictionaries (they can be mixed).
 
 ```python
 xml = exemel.build({

--- a/exemel.py
+++ b/exemel.py
@@ -2,6 +2,12 @@
 
 import collections
 
+try:
+    import collections.abc as abc
+except ImportError:
+    # python2.7 does not have the abc module
+    abc = collections
+
 from future.utils import iteritems
 from lxml import etree
 
@@ -15,7 +21,7 @@ def build(dictionary, root='root', encoding=None):
     """Builds an XML element from a dictionary-like object
 
     Args:
-        dictionary (collections.Mapping): The structure to be converted
+        dictionary (collections.abc.Mapping): The structure to be converted
 
     Keyword Args:
         root (string):     The tag of the root element. Defaults to 'root'.
@@ -35,7 +41,7 @@ def build_element(dictionary, root='root'):
     """Builds an XML element from a dictionary-like object
 
     Args:
-        dictionary (collections.Mapping): The structure to be converted
+        dictionary (collections.abc.Mapping): The structure to be converted
 
     Keyword Args:
         root (string): The tag of the root element. Defaults to 'root'.
@@ -90,9 +96,9 @@ def _add_sub_elements(element, name, value, namespace):
     if etree.iselement(value):
         _validate_element_name(value, name)
         element.append(value)
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, abc.Mapping):
         element.append(_build_element_from_dict(name, value, namespace))
-    elif (isinstance(value, collections.Iterable) and
+    elif (isinstance(value, abc.Iterable) and
           not isinstance(value, str)):
         for sub_elem in _build_elements_from_iterable(name, value, namespace):
             element.append(sub_elem)
@@ -105,7 +111,7 @@ def _build_elements_from_iterable(name, iterable, parent_namespace):
         if etree.iselement(item):
             _validate_element_name(item, name)
             element = item
-        elif isinstance(item, collections.Mapping):
+        elif isinstance(item, abc.Mapping):
             element = _build_element_from_dict(name, item, parent_namespace)
         else:
             element = _build_element_from_value(name, item, parent_namespace)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py35,py36,py37,py38
 
 [testenv]
 deps =


### PR DESCRIPTION
- Maintain backwards compatibility with python2.7.
- Remove support for python3.4 which has passed end-of-life support.